### PR TITLE
fix memory leak and overflow issues

### DIFF
--- a/file_io.c
+++ b/file_io.c
@@ -237,7 +237,7 @@ BOOL SaveFileDialog(HWND owner, WCHAR *pathOut, DWORD pathLen) {
     ofn.Flags = OFN_OVERWRITEPROMPT | OFN_PATHMUSTEXIST;
     ofn.lpstrDefExt = L"txt";
     if (pathOut[0] == L'\0') {
-        StringCchCopyW(pathOut, pathLen, L"*.txt");
+        StringCchCopyW(pathOut, pathLen, L"Untitled.txt");
     }
     return GetSaveFileNameW(&ofn);
 }

--- a/retropad.c
+++ b/retropad.c
@@ -182,6 +182,13 @@ static int ReplaceAllOccurrences(HWND hwndEdit, const WCHAR *needle, const WCHAR
     }
 
     size_t newLen = (size_t)len - (size_t)count * needleLen + (size_t)count * replLen;
+    if (newLen > INT_MAX / sizeof(WCHAR)) {
+        HeapFree(GetProcessHeap(), 0, text);
+        HeapFree(GetProcessHeap(), 0, searchBuf);
+        HeapFree(GetProcessHeap(), 0, needleBuf);
+        MessageBoxW(NULL, L"Replacement text too large.", L"retropad", MB_ICONERROR);
+        return 0;
+    }
     WCHAR *result = (WCHAR *)HeapAlloc(GetProcessHeap(), 0, (newLen + 1) * sizeof(WCHAR));
     if (!result) {
         HeapFree(GetProcessHeap(), 0, text);

--- a/retropad.c
+++ b/retropad.c
@@ -76,7 +76,7 @@ static BOOL FindInEdit(HWND hwndEdit, const WCHAR *needle, BOOL matchCase, BOOL 
     if (!GetEditText(hwndEdit, &text, &len)) return FALSE;
 
     size_t needleLen = wcslen(needle);
-    WCHAR *haystack = text;
+    WCHAR *haystack = NULL;
     WCHAR *needleBuf = (WCHAR *)HeapAlloc(GetProcessHeap(), 0, (needleLen + 1) * sizeof(WCHAR));
     if (!needleBuf) {
         HeapFree(GetProcessHeap(), 0, text);
@@ -85,8 +85,17 @@ static BOOL FindInEdit(HWND hwndEdit, const WCHAR *needle, BOOL matchCase, BOOL 
     StringCchCopyW(needleBuf, needleLen + 1, needle);
 
     if (!matchCase) {
+        haystack = (WCHAR *)HeapAlloc(GetProcessHeap(), 0, (len + 1) * sizeof(WCHAR));
+        if (!haystack) {
+            HeapFree(GetProcessHeap(), 0, text);
+            HeapFree(GetProcessHeap(), 0, needleBuf);
+            return FALSE;
+        }
+        StringCchCopyW(haystack, len + 1, text);
         CharLowerBuffW(haystack, len);
         CharLowerBuffW(needleBuf, (DWORD)needleLen);
+    } else {
+        haystack = text;
     }
 
     if (startPos > (DWORD)len) startPos = (DWORD)len;
@@ -125,6 +134,9 @@ static BOOL FindInEdit(HWND hwndEdit, const WCHAR *needle, BOOL matchCase, BOOL 
         result = TRUE;
     }
 
+    if (!matchCase && haystack != text) {
+        HeapFree(GetProcessHeap(), 0, haystack);
+    }
     HeapFree(GetProcessHeap(), 0, text);
     HeapFree(GetProcessHeap(), 0, needleBuf);
     return result;


### PR DESCRIPTION
found and fixed a few critical bugs while reviewing the code:

**memory leak in search**
the case-insensitive search was corrupting the original text buffer by calling `CharLowerBuffW` directly on it. now we create a separate copy for comparison, keeping the original safe.

**overflow protection in replace all**
when replacing text in large files, the buffer size calculation could overflow. added a check to prevent crashes when the result would be too large.

**better default filename**
changed the save dialog default from `*.txt` (which is a wildcard) to `Untitled.txt` -which makes more sense-.

tested all fixes with msvc, no warnings or issues found