### PR TITLE
FIX: Use correct url for this repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Optional: MinGW-w64 for `make` + `gcc` (a separate POSIX-style `Makefile` is inc
 
 ## Get the code
 ```bat
-git clone https://github.com/your/repo.git retropad
+git clone https://github.com/PlummersSoftwareLLC/retropad.git
 cd retropad
 ```
 


### PR DESCRIPTION
The url in the README.md file is now correct, so the user can just click to copy instead of having to change it manually to the correct url.